### PR TITLE
refactor logic to search by jury and file and modify table

### DIFF
--- a/app/components/MatchedTable/index.tsx
+++ b/app/components/MatchedTable/index.tsx
@@ -40,9 +40,6 @@ function MatchedFilesTable(props: { matchedFiles: any[] }) {
             <div className='overflow-scroll'>
               <div className='mt-4 lg:mt-4 mx-auto min-w-[800px] max-w-7xl lg:px-8'>
                 <div className='flex items-center border-b-2 justify-between border-gray-300 '>
-                  <p className='text-center font-semibold  text-sm lg:text-lg flex-1 '>
-                    Numero de archivo
-                  </p>
                   <p className='text-center font-semibold text-sm lg:text-lg flex-[2_2_0] '>
                     Expediente
                   </p>
@@ -60,14 +57,11 @@ function MatchedFilesTable(props: { matchedFiles: any[] }) {
                       key={index}
                       className='flex py-2 lg:py-4 items-center justify-between  border-b border-gray-300'
                     >
-                      <p className='flex-1 text-center text-sm lg:text-base text-gray-500'>
-                        {file[0]}
+                      <p className='flex-[3_3_0] text-center text-sm lg:text-base text-gray-500'>
+                        {file[3]}
                       </p>
                       <p className='flex-[2_2_0] text-center text-sm lg:text-base'>
                         {file[1]}
-                      </p>
-                      <p className='flex-[3_3_0] text-center text-sm lg:text-base text-gray-500'>
-                        {file[3]}
                       </p>
                       <p className='flex-[5_5_0] text-center text-sm lg:text-base text-gray-500'>
                         {file[2]}

--- a/functions/boletin.ts
+++ b/functions/boletin.ts
@@ -1,9 +1,9 @@
 const moment = require('moment-timezone')
 const jsdom = require('jsdom')
 const tabletojson = require('tabletojson').Tabletojson
-const fs = require('fs')
 
 interface BoletinData {
+  files: any
   status: number
   data: {
     files?: Record<string, unknown>[]
@@ -30,102 +30,62 @@ export async function getBoletinData(
   const URL = `http://www.pjbc.gob.mx/boletinj/${year}/my_html/${municipality}${formattedDate}.htm`
 
   // Get htm data and convert it to JSON
+  try {
+    const response = await fetch(URL)
+    const html = await response.text()
 
-  fs.readFile(`/tmp/${formattedDate}.json`, 'utf8', function (err, data) {
-    if (err) {
-      console.log(err)
-    } else {
-      console.log('file exists')
-      console.log(data)
+    // Process the HTML here
+    const dom = new jsdom.JSDOM(html)
+    const mainSection = dom.window.document.querySelector('.WordSection1')
+
+    if (!mainSection) {
+      return {
+        status: 204,
+        data: { message: 'No hay informacion de este boletin' },
+      }
     }
-  })
 
-  if (fs.existsSync(`/tmp/${formattedDate}.json`)) {
-    console.log('file exists')
-    const data = fs.readFileSync(`/tmp/${formattedDate}.json`, 'utf8')
-    console.log(data)
+    const juryCases = {}
+    let currentJury = ''
+
+    // The following code iterates through each item in the jury file and uses the previous variables to
+    // keep track of which files corespond to which jury and change jury when a new section is reached
+    for (const child of mainSection.children) {
+      // @ts-ignore
+      if (child.tagName === 'DIV') {
+        const reformattedContent = child.textContent.replace(/\n/g, ' ').trim()
+        juryCases[reformattedContent] = []
+        currentJury = reformattedContent
+      } else if (child.tagName === 'TABLE') {
+        const jsonTableData = tabletojson.convert(child.outerHTML)
+        const jsonTableDataFlat = jsonTableData.flat(1)
+        juryCases[currentJury].push(jsonTableDataFlat)
+      }
+    }
+
+    // Flatten out each array for each jury
+    const flattenedJuryFilesObj = Object.entries(juryCases).map(([key, files]) => {
+      return {
+        key: key,
+        files: files.flat(),
+      };
+    });
+
     return {
       status: 200,
-      data: {
-        files: JSON.parse(data),
-        datetime,
-        url: URL,
-      },
+      files: flattenedJuryFilesObj,
+      datetime,
+      url: URL,
     }
-  } else {
-    try {
-      const response = await fetch(URL)
-      const html = await response.text()
-
-      // Process the HTML here
-      const dom = new jsdom.JSDOM(html)
-      const mainSection = dom.window.document.querySelector('.WordSection1')
-
-      if (!mainSection) {
-        return {
-          status: 204,
-          data: { message: 'No hay informacion de este boletin' },
-        }
-      }
-
-      const juryCases = {}
-      let currentJury = ''
-
-      // The following code iterates through each item in the jury file and uses the previous variables to
-      // keep track of which files corespond to which jury and change jury when a new section is reached
-      for (const child of mainSection.children) {
-        // @ts-ignore
-        if (child.tagName === 'DIV') {
-          const reformattedContent = child.textContent
-            .replace(/\n/g, ' ')
-            .trim()
-          juryCases[reformattedContent] = []
-          currentJury = reformattedContent
-        } else if (child.tagName === 'TABLE') {
-          const jsonTableData = tabletojson.convert(child.outerHTML)
-          const jsonTableDataFlat = jsonTableData.flat(1)
-          juryCases[currentJury].push(jsonTableDataFlat)
-        }
-      }
-
-      // Flatten out each array for each jury
-      const flattenedJuryFilesObj = Object.entries(juryCases).map(item => {
-        return {
-          key: item[0],
-          files: item[1].flat(),
-        }
-      })
-
-      exports.handler = function (event, context) {
-        fs.writeFile(
-          `/tmp/${formattedDate}.json`,
-          JSON.stringify(flattenedJuryFilesObj),
-          function (err) {
-            if (err) {
-              context.fail(err)
-            } else {
-              context.succeed('Success')
-            }
-          },
-          context.done
-        )
-      }
-
-      return {
-        status: 200,
-        files: flattenedJuryFilesObj,
+  } catch (error: any) {
+    console.error(error)
+    return {
+      status: 500,
+      data: {
+        error: error.message,
         datetime,
-        url: URL,
-      }
-    } catch (error: any) {
-      console.error(error)
-      return {
-        status: 500,
-        data: {
-          error: error.message,
-          datetime,
-        },
-      }
+      },
     }
   }
 }
+


### PR DESCRIPTION
- refactorize las funciones del boletin para trabajar con la primera columna del excel que es el jurado/juzgado y no solo con el fileid

- se hace un mapeo de los jurados siguiendo la siguiente convencion:
  - "{numero de juzgado} {tipo de juzgado}"
  - ej. "1 civil", "1 familiar"

- se imprime un nuevo mensaje al no encontrar coincidencias entre el archivo y el boletin

entre otras cosas que quiza no recuerdo xd

edit: 
aah si, tambien quite la logica de guardar un archivo, ya que en las netlify functions no funciona, pero lo podemos considerar si desacoplamos las funciones de netlify a un api o similar
