### PR TITLE
fix | start from first row

### DIFF
--- a/functions/file-management.ts
+++ b/functions/file-management.ts
@@ -16,7 +16,7 @@ export async function getExcelColumns(workingSheet: any) {
   const excelColumns = xlsx.utils.sheet_to_json(workingSheet,
     {
       header: 1,
-      range: 2,
+      range: 0,
       raw: false,
       defval: null,
       blankrows: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Boletin judicial",
+  "name": "boletin-judicial",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Modifique la funcion xlsx para que empiece a hacer el parseo de la informacion desde el primer row,
es el campo "range", malentendi la funcion y pense que este parametro era el numero de columnas que tomaba, pero en realidad es el row donde inicia a hacer el parseo